### PR TITLE
Stop using tmpnam, it is no longer supported in perl 5.26 

### DIFF
--- a/package/yast2-instserver.changes
+++ b/package/yast2-instserver.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  5 13:13:54 UTC 2017 - mvidner@suse.com
+
+- Stop using tmpnam, it is no longer supported in perl 5.26
+  (bsc#1061620)
+- 4.0.0
+
+-------------------------------------------------------------------
 Thu Jul 27 12:16:29 UTC 2017 - jreidinger@suse.com
 
 - move from yast2 agent for reading /content to support install of

--- a/package/yast2-instserver.spec
+++ b/package/yast2-instserver.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-instserver
-Version:        3.3.0
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/servers_non_y2/ag_content
+++ b/src/servers_non_y2/ag_content
@@ -8,7 +8,6 @@ use YaST::SCRAgent;
 use diagnostics;
 
 use Getopt::Long;
-use POSIX qw(tmpnam);
 use IO::File;
 
 our @ISA = ("YaST::SCRAgent");


### PR DESCRIPTION
- [bsc#1061620](https://bugzilla.suse.com/show_bug.cgi?id=1061620)
- https://trello.com/c/EVu9oWwb