### PR TITLE
Drop xinetd configuration

### DIFF
--- a/package/yast2-instserver.changes
+++ b/package/yast2-instserver.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  8 11:54:52 UTC 2018 - knut.anderssen@suse.com
+
+- Drop xinetd configuration and use systemd sockets instead.
+  (fate#323373)
+- 4.0.2
+
+-------------------------------------------------------------------
 Mon Feb  5 13:39:28 UTC 2018 - knut.anderssen@suse.com
 
 - Replace SuSEFirewall2 by firewalld (fate#323460)

--- a/package/yast2-instserver.spec
+++ b/package/yast2-instserver.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-instserver
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
I have tested the changes manually, and it works fine with a SLE12 and Leap42 but the module is not ready for the new SLE15 iso layout just to take in account an probably fill a new bug for it.