### PR TITLE
Fixed importing a SLE15 installation medium (bsc#1103621)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ Makefile.am.common
 tmp.*
 *.log
 *.ybc
+/.yardoc
+/doc
+!/doc/SPEC
+*.exp
+runtest.sh

--- a/package/yast2-instserver.changes
+++ b/package/yast2-instserver.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 15 13:42:35 UTC 2018 - lslezak@suse.cz
+
+- Do not crash when importing a SLE15 installation medium
+  (bsc#1103621)
+- 3.1.6
+
+-------------------------------------------------------------------
 Wed Jun  1 13:58:26 UTC 2016 - igonzalezsosa@suse.com
 
 - Drop yast2-instserver-devel-doc package (fate#320356)

--- a/package/yast2-instserver.spec
+++ b/package/yast2-instserver.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-instserver
-Version:        3.1.5
+Version:        3.1.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/instserver/dialogs.rb
+++ b/src/include/instserver/dialogs.rb
@@ -388,18 +388,17 @@ module Yast
             )
           end
 
-          content = ReadContentFile(Ops.add(cdpath, "/content"))
+          content_path = File.join(cdpath, "content")
+          content = ReadContentFile(content_path) if File.exist?(content_path)
           Builtins.y2milestone("Content file: %1", content)
           # don't rewrite the already read content file,
           # content file from CORE9 would rewrite already read file from SLES9
           if current_cd == 1 && content_first_CD == ""
             Builtins.y2milestone(
               "Reading content file %1",
-              Ops.add(cdpath, "/content")
+              content_path
             )
-            content_first_CD = Convert.to_string(
-              SCR.Read(path(".target.string"), Ops.add(cdpath, "/content"))
-            )
+            content_first_CD = File.read(content_path) if File.exist?(content_path)
             Builtins.y2debug("content file: %1", content_first_CD)
           end
           if Ops.get(media, 2, "") != "" &&


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1103621
- 3.1.6
- Fortunately it turned out that it's enough just to skip reading the `content` file if it does not exist, the rest works as expected.
- Tested manually, booted the SLE15 medium with `install=http://...` parameter pointing to the installation server, the installation started as usually.


## Screenshots

- The YaST module can now import a SLE15 medium correctly:
![inst_server_sle15](https://user-images.githubusercontent.com/907998/44152804-bae32ee8-a0a6-11e8-80ed-836553f234ab.png)
- The repository is properly exported, all files are present
![inst_server_http](https://user-images.githubusercontent.com/907998/44152840-d08c572e-a0a6-11e8-942b-d993a2ab7b6e.png)
