### PR TITLE
Stop using the `nfsserver` service alias

### DIFF
--- a/package/yast2-instserver.changes
+++ b/package/yast2-instserver.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 21 16:19:19 UTC 2018 - dgonzalez@suse.com
+
+- Use the nfs-server service real name instead an alias
+  (bsc#1116779).
+- 4.1.3
+
+-------------------------------------------------------------------
 Tue Oct 16 11:58:29 CEST 2018 - schubi@suse.de
 
 - Fixed path to license file. . Build error in bsc#1110037.

--- a/package/yast2-instserver.spec
+++ b/package/yast2-instserver.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-instserver
-Version:        4.1.2
+Version:        4.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Instserver.rb
+++ b/src/modules/Instserver.rb
@@ -13,6 +13,8 @@ require "yast2/systemd/socket"
 
 module Yast
   class InstserverClass < Module
+    NFS_SERVER_SEVICE = "nfs-server".freeze
+
     def main
       textdomain "instserver"
 
@@ -549,11 +551,11 @@ module Yast
 
       ConfigureService("nfs_server_auto", nfs)
 
-      Service.Enable("nfsserver")
-      if Service.Status("nfsserver") == 0
-        Service.Reload("nfsserver")
+      Service.Enable(NFS_SERVER_SERVICE)
+      if Service.Status(NFS_SERVER_SERVICE) == 0
+        Service.Reload(NFS_SERVER_SERVICE)
       else
-        Service.Start("nfsserver")
+        Service.Start(NFS_SERVER_SERVICE)
       end
 
       firewalld.write
@@ -1013,7 +1015,7 @@ module Yast
       # is the directory in /etc/exports?
       return false if !NFSExported(dir)
 
-      nfsserver_running = Service.Status("nfsserver") == 0
+      nfsserver_running = Service.Status(NFS_SERVER_SERVICE) == 0
       Builtins.y2milestone("NFS server running: %1", nfsserver_running)
 
       # is the nfsserver running?


### PR DESCRIPTION
From `nfs-utils-2.3.3` on, it is needed to use the proper service name for `nfs-server` since the `nfsserver` alias has been removed ([see request](https://build.opensuse.org/request/show/644756)). 

Related to https://bugzilla.suse.com/show_bug.cgi?id=1116779