### PR TITLE
fix parsing DISTRO from 'content' file (bsc#1122003)

### DIFF
--- a/src/include/instserver/routines.rb
+++ b/src/include/instserver/routines.rb
@@ -25,6 +25,27 @@ module Yast
       end
     end
 
+    # Split at the *last* comma (cf. bsc#1122003), resulting in 2 parts maximum.
+    # @param [String] distro "DISTRO" value from content file
+    # @return [Array<String,String>]
+    #
+    # The distro arg could look like
+    #   "cpe:/o:suse:sles:12,SUSE Linux Enterprise Server 12"
+    #   "cpe:/o:suse:sles:12:sp3,SUSE Linux Enterprise Server 12 SP3"
+    #   "cpe:/o:novell,inc:sles:12:sp3,SUSE Linux Enterprise Server 12 SP3"
+    #
+    # The match below assumes the cpe string are fields containing no white
+    # space separated by ':' optionally followed by a ',' and an arbitrary
+    # product name.
+    #
+    def distro_split(distro)
+      distro.match(/((?:[^:\s]*:)+[^,]*),?(.*)?/) do |m|
+        return m[1, 2]
+      end
+
+      [distro, '']
+    end
+
     # Split CPE ID and distro label (separated by comma)
     # @param [String] distro "DISTRO" value from content file
     # @return [Hash<String,String>,nil] parsed value, map: { "name" => <string>, "cpeid" => <string> }
@@ -35,10 +56,9 @@ module Yast
         return nil
       end
 
-      # split at the first comma, resulting in 2 parts at max.
-      cpeid, name = distro.split(",", 2)
+      cpeid, name = distro_split(distro)
 
-      if !name
+      if name.empty?
         log.warn "Cannot parse DISTRO value: #{distro}"
         return nil
       end

--- a/src/include/instserver/routines.rb
+++ b/src/include/instserver/routines.rb
@@ -38,6 +38,8 @@ module Yast
     # space separated by ':' optionally followed by a ',' and an arbitrary
     # product name.
     #
+    # For the CPE format specs see http://cpe.mitre.org.
+    #
     def distro_split(distro)
       distro.match(/((?:[^:\s]*:)+[^,]*),?(.*)?/) do |m|
         return m[1, 2]

--- a/src/include/instserver/routines.rb
+++ b/src/include/instserver/routines.rb
@@ -25,7 +25,8 @@ module Yast
       end
     end
 
-    # Split at the *last* comma (cf. bsc#1122003), resulting in 2 parts maximum.
+    # Split CPE id and distro label (separated by comma)
+    # Be extra careful as there might be commas in the CPE string itself (bsc#1122003).
     # @param [String] distro "DISTRO" value from content file
     # @return [Array<String,String>]
     #

--- a/test/routines_test.rb
+++ b/test/routines_test.rb
@@ -30,6 +30,18 @@ describe "Yast::InstserverRoutinesInclude" do
           "name" => "SLES12, Mini edition"})
     end
 
+    it "works also when CPE fields contain commas" do
+      expect(subject.distro_map("cpe:/o:novell,inc:sles:12,SLES12, Mini edition")).
+        to eq({"cpeid" => "cpe:/o:novell,inc:sles:12",
+          "name" => "SLES12, Mini edition"})
+    end
+
+    it "the number of CPE fields may vary" do
+      expect(subject.distro_map("cpe:/o:novell,inc:sles:12:sp5,SLES12 SP5")).
+        to eq({"cpeid" => "cpe:/o:novell,inc:sles:12:sp5",
+          "name" => "SLES12 SP5"})
+    end
+
     it "returns nil if input is nil" do
       expect(subject.distro_map(nil)).to be_nil
     end


### PR DESCRIPTION
There might be more than one comma (",") in the string. Assume the cpe string and the product
name might both contain commas.

> Note:
> The CPE string specs were guessed from the examples at http://cpe.mitre.org as the specs
> can't currently be downloaded due to the U.S. government shutdown.