### PR TITLE
Fix typo in constant

### DIFF
--- a/package/yast2-instserver.changes
+++ b/package/yast2-instserver.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 18 09:10:01 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not crash when starting the Installation Server (bsc#1141963).
+- 4.1.6
+
+-------------------------------------------------------------------
 Tue Dec  4 11:07:15 UTC 2018 - jreidinger@suse.com
 
 - always use absolute path to binaries (bsc#1118291)

--- a/package/yast2-instserver.spec
+++ b/package/yast2-instserver.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-instserver
-Version:        4.1.5
+Version:        4.1.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Instserver.rb
+++ b/src/modules/Instserver.rb
@@ -14,7 +14,7 @@ require "shellwords"
 
 module Yast
   class InstserverClass < Module
-    NFS_SERVER_SEVICE = "nfs-server".freeze
+    NFS_SERVER_SERVICE = "nfs-server".freeze
 
     def main
       textdomain "instserver"


### PR DESCRIPTION
## Problem

At the time to _Stop using the `nfsserver` service alias (#33)_, a typo was introduced in the added constant to hold the `nfs-sever` service name.

https://bugzilla.suse.com/show_bug.cgi?id=1141963

## Solution

Fix it and **add the missing unit test** :see_no_evil:.

## Tests

Added a unit test.
