### PR TITLE
Added "BuildRequires: update-desktop-files"

### DIFF
--- a/package/yast2-instserver.changes
+++ b/package/yast2-instserver.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 06:59:17 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.2
+
+-------------------------------------------------------------------
 Thu Jul 18 09:10:01 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Do not crash when starting the Installation Server (bsc#1141963).

--- a/package/yast2-instserver.spec
+++ b/package/yast2-instserver.spec
@@ -27,6 +27,7 @@ License:        GPL-2.0-or-later
 Source0:        %{name}-%{version}.tar.bz2
 Source1:        inst_server.conf.in
 
+BuildRequires:  update-desktop-files
 # Yast2::Systemd::Socket
 BuildRequires:  yast2 >= 4.1.3
 BuildRequires:  yast2-devtools >= 4.2.2


### PR DESCRIPTION
- The recent fix in YaST RPM macros now updates the desktop files
- The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
- Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`